### PR TITLE
Reset label home position in initialization string

### DIFF
--- a/ZPLUtility/ZPLEngine.cs
+++ b/ZPLUtility/ZPLEngine.cs
@@ -27,7 +27,7 @@ namespace BinaryKits.Utility.ZPLUtility
         {
             List<string> result = new List<string>
             {
-                "^XA",
+                "^XA^LH0,0",
                 context.ChangeInternationalFontEncoding
             };
             foreach (var e in this.Where(x => x.IsEnabled))


### PR DESCRIPTION
This makes the ZPL string properly printable. Without ^LH0,0 after ^XA, prints will be off-center.