### PR TITLE
Fix "Application" namespace clash.

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/IZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/IZplAnalyzer.cs
@@ -1,6 +1,6 @@
 ﻿using BinaryKits.Zpl.Viewer.Models;
 
-namespace Application.UseCase.ZplToPdf
+namespace BinaryKits.Zpl.Viewer
 {
     public interface IZplAnalyzer
     {

--- a/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Application.UseCase.ZplToPdf;
 
 namespace BinaryKits.Zpl.Viewer
 {


### PR DESCRIPTION
Fixes [#264](https://github.com/BinaryKits/BinaryKits.Zpl/issues/264)
Application namesapce conflicts with class System.Windows.Forms.Application