### PR TITLE
Use IEnumerable instead of Array in Draw methods

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -60,7 +60,7 @@ namespace BinaryKits.Zpl.Viewer
         /// <param name="printDensityDpmm">Dots per millimeter</param>
         /// <returns></returns>
         public byte[] Draw(
-            ZplElementBase[] elements,
+            IEnumerable<ZplElementBase> elements,
             double labelWidth = 101.6,
             double labelHeight = 152.4,
             int printDensityDpmm = 8)
@@ -77,7 +77,7 @@ namespace BinaryKits.Zpl.Viewer
         /// <param name="printDensityDpmm">Dots per millimeter</param>
         /// <returns></returns>
         public byte[] DrawPdf(
-            ZplElementBase[] elements,
+            IEnumerable<ZplElementBase> elements,
             double labelWidth = 101.6,
             double labelHeight = 152.4,
             int printDensityDpmm = 8)
@@ -94,7 +94,7 @@ namespace BinaryKits.Zpl.Viewer
         /// <param name="printDensityDpmm">Dots per millimeter</param>
         /// <returns></returns>
         public List<byte[]> DrawMulti(
-            ZplElementBase[] elements,
+            IEnumerable<ZplElementBase> elements,
             double labelWidth = 101.6,
             double labelHeight = 152.4,
             int printDensityDpmm = 8)
@@ -275,7 +275,7 @@ namespace BinaryKits.Zpl.Viewer
         /// <param name="printDensityDpmm">Dots per millimeter</param>
         /// <returns></returns>
         public void DrawSurface(SKSurface surface,
-            ZplElementBase[] elements,
+            IEnumerable<ZplElementBase> elements,
             double labelWidth = 101.6,
             double labelHeight = 152.4,
             int printDensityDpmm = 8)


### PR DESCRIPTION
Updated method signatures to accept IEnumerable instead of array for better flexibility.