### PR TITLE
Avoid allocating analyzers and drawers each call

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/AnsiCodabarBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/AnsiCodabarBarcodeZplCommandAnalyzer.cs
@@ -6,20 +6,20 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class AnsiCodabarBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public AnsiCodabarBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BK", virtualPrinter) { }
+        public AnsiCodabarBarcodeZplCommandAnalyzer() : base("^BK") { }
 
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             bool checkDigit = false;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
             char startCharacter = 'A';
             char stopCharacter = 'A';
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             if (zplDataParts.Length > 1)
             {
@@ -52,7 +52,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new AnsiCodabarFieldData
+            virtualPrinter.SetNextElementFieldData(new AnsiCodabarFieldData
             {
                 FieldOrientation = fieldOrientation,
                 StartCharacter = startCharacter,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/AztecBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/AztecBarcodeZplCommandAnalyzer.cs
@@ -6,15 +6,15 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class AztecBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public AztecBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BO", virtualPrinter) { }
+        public AztecBarcodeZplCommandAnalyzer() : base("^BO") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             int tmpint;
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
             int magnificationFactor = 2;
             bool extendedChannel = false;
             int errorControl = 0;
@@ -52,7 +52,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 idField = zplDataParts[6];
             }
 
-            this.VirtualPrinter.SetNextElementFieldData(new AztecBarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new AztecBarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 MagnificationFactor = magnificationFactor,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/BarCodeFieldDefaultZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/BarCodeFieldDefaultZplCommandAnalyzer.cs
@@ -4,10 +4,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class BarCodeFieldDefaultZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public BarCodeFieldDefaultZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BY", virtualPrinter) { }
+        public BarCodeFieldDefaultZplCommandAnalyzer() : base("^BY") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -32,9 +32,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 barcodeHeight = tmpint;
             }
 
-            this.VirtualPrinter.SetBarcodeModuleWidth(moduleWidth);
-            this.VirtualPrinter.SetBarcodeWideBarToNarrowBarWidthRatio(wideBarToNarrowBarWidthRatio);
-            this.VirtualPrinter.SetBarcodeHeight(barcodeHeight);
+            virtualPrinter.SetBarcodeModuleWidth(moduleWidth);
+            virtualPrinter.SetBarcodeWideBarToNarrowBarWidthRatio(wideBarToNarrowBarWidthRatio);
+            virtualPrinter.SetBarcodeHeight(barcodeHeight);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ChangeAlphanumericDefaultFontZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ChangeAlphanumericDefaultFontZplCommandAnalyzer.cs
@@ -4,14 +4,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class ChangeAlphanumericDefaultFontZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public ChangeAlphanumericDefaultFontZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^CF", virtualPrinter) { }
+        public ChangeAlphanumericDefaultFontZplCommandAnalyzer() : base("^CF") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            this.VirtualPrinter.SetFontName(zplDataParts[0]);
+            virtualPrinter.SetFontName(zplDataParts[0]);
 
             int tmpint;
             int fontHeight = 9;
@@ -27,8 +27,8 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 fontWidth = tmpint;
             }
 
-            this.VirtualPrinter.SetFontHeight(fontHeight);
-            this.VirtualPrinter.SetFontWidth(fontWidth);
+            virtualPrinter.SetFontHeight(fontHeight);
+            virtualPrinter.SetFontWidth(fontWidth);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ChangeInternationalFontCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ChangeInternationalFontCommandAnalyzer.cs
@@ -8,9 +8,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     public class ChangeInternationalFontCommandAnalyzer : ZplCommandAnalyzerBase
     {
 
-        public ChangeInternationalFontCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^CI", virtualPrinter) { }
+        public ChangeInternationalFontCommandAnalyzer() : base("^CI") { }
 
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string charSet = zplCommand.Substring(this.PrinterCommandPrefix.Length);
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code128BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code128BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -6,17 +6,17 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Code128BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Code128BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BC", virtualPrinter) { }
+        public Code128BarcodeZplCommandAnalyzer() : base("^BC") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
             bool uccCheckDigit = false;
@@ -48,7 +48,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new Code128BarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new Code128BarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code39BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code39BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -6,20 +6,20 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Code39BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Code39BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B3", virtualPrinter) { }
+        public Code39BarcodeZplCommandAnalyzer() : base("^B3") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             int tmpint;
             bool mod43CheckDigit = false;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
             if (zplDataParts.Length > 1)
             {
                 mod43CheckDigit = this.ConvertBoolean(zplDataParts[1]);
@@ -41,7 +41,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new Code39BarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new Code39BarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code93BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Code93BarcodeZplCommandAnalyzer.cs
@@ -6,20 +6,20 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Code93BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Code93BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BA", virtualPrinter) { }
+        public Code93BarcodeZplCommandAnalyzer() : base("^BA") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             int tmpint;
             bool printCheckDigit = false;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
                 height = tmpint;
@@ -41,7 +41,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new Code93BarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new Code93BarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CodeEAN13BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CodeEAN13BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -6,17 +6,17 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class CodeEAN13BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public CodeEAN13BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BE", virtualPrinter) { }
+        public CodeEAN13BarcodeZplCommandAnalyzer() : base("^BE") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
 
@@ -36,7 +36,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new CodeEAN13BarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new CodeEAN13BarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CommentZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/CommentZplCommandAnalyzer.cs
@@ -4,13 +4,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class CommentZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public CommentZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FX", virtualPrinter) { }
+        public CommentZplCommandAnalyzer() : base("^FX") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string comment = zplCommand.Substring(this.PrinterCommandPrefix.Length);
-            this.VirtualPrinter.AddComment(comment);
+            virtualPrinter.AddComment(comment);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DataMatrixZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DataMatrixZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -6,17 +6,17 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class DataMatrixZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public DataMatrixZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BX", virtualPrinter) { }
+        public DataMatrixZplCommandAnalyzer() : base("^BX") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             QualityLevel qualityLevel = QualityLevel.ECC0;
 
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
@@ -30,7 +30,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new DataMatrixFieldData
+            virtualPrinter.SetNextElementFieldData(new DataMatrixFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadFormatCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadFormatCommandAnalyzer.cs
@@ -8,10 +8,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private static readonly Regex commandRegex = new(@"^\^DF(\w:)?(.*?)?(\..+?)?$", RegexOptions.Compiled);
 
-        public DownloadFormatCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^DF", virtualPrinter) { }
+        public DownloadFormatCommandAnalyzer() : base("^DF") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             Match commandMatch = commandRegex.Match(zplCommand);
             if (commandMatch.Success)
@@ -19,7 +19,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 char storageDevice = commandMatch.Groups[1].Success ? commandMatch.Groups[1].Value[0] : 'R';
                 string formatName = commandMatch.Groups[2].Value;
 
-                this.VirtualPrinter.SetNextDownloadFormatName(formatName);
+                virtualPrinter.SetNextDownloadFormatName(formatName);
             }
 
             return null;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadGraphicsZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadGraphicsZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label.Elements;
+﻿using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Label.ImageConverters;
 using BinaryKits.Zpl.Viewer.Helpers;
 
@@ -10,16 +10,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private static readonly Regex commandRegex = new(@"^~DG(\w:)?(.*?\..+?),(\d+),(\d+),(.+)$", RegexOptions.Compiled);
 
-        private readonly IPrinterStorage printerStorage;
-
-        public DownloadGraphicsZplCommandAnalyzer(VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
-            : base("~DG", virtualPrinter)
-        {
-            this.printerStorage = printerStorage;
-        }
+        public DownloadGraphicsZplCommandAnalyzer() : base("~DG") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             Match commandMatch = commandRegex.Match(zplCommand);
             if (commandMatch.Success)
@@ -37,7 +31,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 ImageSharpImageConverter converter = new();
                 byte[] imageData = converter.ConvertImage(grfImageData, numberOfBytesPerRow);
 
-                this.printerStorage.AddFile(storageDevice, imageName, imageData);
+                printerStorage.AddFile(storageDevice, imageName, imageData);
             }
 
             return null;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadObjectsZplCommandAnaylzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/DownloadObjectsZplCommandAnaylzer.cs
@@ -5,16 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class DownloadObjectsZplCommandAnaylzer : ZplCommandAnalyzerBase
     {
-        private readonly IPrinterStorage printerStorage;
-
-        public DownloadObjectsZplCommandAnaylzer(VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
-            : base("~DY", virtualPrinter)
-        {
-            this.printerStorage = printerStorage;
-        }
+        public DownloadObjectsZplCommandAnaylzer() : base("~DY") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             char storageDevice = zplCommand[this.PrinterCommandPrefix.Length];
 
@@ -29,7 +23,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             // TODO: Handle case when .GRF data is downloaded using the ~DY command
             string dataHex = zplDataParts[5];
 
-            this.printerStorage.AddFile(storageDevice, objectName, ByteHelper.HexToBytes(dataHex));
+            printerStorage.AddFile(storageDevice, objectName, ByteHelper.HexToBytes(dataHex));
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldBlockZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldBlockZplCommandAnalyzer.cs
@@ -6,11 +6,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldBlockZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldBlockZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FB", virtualPrinter)
-        { }
+        public FieldBlockZplCommandAnalyzer() : base("^FB")        { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -57,7 +56,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 hangingIndentOfTheSecondAndRemainingLines = tmpint;
             }
 
-            this.VirtualPrinter.SetNextElementFieldBlock(new FieldBlock
+            virtualPrinter.SetNextElementFieldBlock(new FieldBlock
             {
                 WidthOfTextBlockLine = widthOfTextBlockLine,
                 MaximumNumberOfLinesInTextBlock = maximumNumberOfLinesInTextBlock,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldDataZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -14,126 +14,126 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         private static readonly Regex qrCodeFieldDataMixedRegex = new(@"^D\d{4}[0-9A-F-a-f]{2},(?<correction>[HQML])(?<input>[AM]),(?<data>.+)$", RegexOptions.Compiled);
         private static readonly Regex qrCodeFieldDataModeRegex = new(@"^(?:[ANK]|(?:B(?<count>\d{4})))(?<data>.+)$", RegexOptions.Compiled);
 
-        public FieldDataZplCommandAnalyzer(VirtualPrinter virtualPrinter, string prefix = "^FD") : base(prefix, virtualPrinter) { }
+        public FieldDataZplCommandAnalyzer(string prefix = "^FD") : base(prefix) { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string text = zplCommand.Substring(this.PrinterCommandPrefix.Length);
 
             // If field data follows a field number, a ZplRecallFieldNumber element has to be returned
-            int? fieldNumber = this.VirtualPrinter.NextFieldNumber;
+            int? fieldNumber = virtualPrinter.NextFieldNumber;
             if (fieldNumber != null)
             {
-                this.VirtualPrinter.ClearNextFieldNumber(); // Prevents consumption by field separator analyzer
+                virtualPrinter.ClearNextFieldNumber(); // Prevents consumption by field separator analyzer
                 return new ZplRecallFieldNumber(fieldNumber.Value, text);
             }
 
             int x = 0;
             int y = 0;
-            char? hexadecimalIndicator = this.VirtualPrinter.NextElementFieldHexadecimalIndicator;
+            char? hexadecimalIndicator = virtualPrinter.NextElementFieldHexadecimalIndicator;
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            FieldJustification fieldJustification = this.VirtualPrinter.NextElementFieldJustification;
+            FieldJustification fieldJustification = virtualPrinter.NextElementFieldJustification;
             if (fieldJustification == FieldJustification.None)
             {
-                fieldJustification = this.VirtualPrinter.FieldJustification;
+                fieldJustification = virtualPrinter.FieldJustification;
             }
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (    virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
-            if (this.VirtualPrinter.NextElementFieldData != null)
+            if (virtualPrinter.NextElementFieldData != null)
             {
-                int moduleWidth = this.VirtualPrinter.BarcodeInfo.ModuleWidth;
-                double wideBarToNarrowBarWidthRatio = this.VirtualPrinter.BarcodeInfo.WideBarToNarrowBarWidthRatio;
+                int moduleWidth = virtualPrinter.BarcodeInfo.ModuleWidth;
+                double wideBarToNarrowBarWidthRatio = virtualPrinter.BarcodeInfo.WideBarToNarrowBarWidthRatio;
 
-                if (this.VirtualPrinter.NextElementFieldData is Code39BarcodeFieldData code39)
+                if (virtualPrinter.NextElementFieldData is Code39BarcodeFieldData code39)
                 {
                     return new ZplBarcode39(text, x, y, code39.Height, moduleWidth, wideBarToNarrowBarWidthRatio, code39.FieldOrientation, hexadecimalIndicator, code39.PrintInterpretationLine, code39.PrintInterpretationLineAboveCode, code39.Mod43CheckDigit, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is Code93BarcodeFieldData code93)
+                else if (virtualPrinter.NextElementFieldData is Code93BarcodeFieldData code93)
                 {
                     return new ZplBarcode93(text, x, y, code93.Height, moduleWidth, wideBarToNarrowBarWidthRatio, code93.FieldOrientation, hexadecimalIndicator, code93.PrintInterpretationLine, code93.PrintInterpretationLineAboveCode, code93.PrintCheckDigit, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is Code128BarcodeFieldData code128)
+                else if (virtualPrinter.NextElementFieldData is Code128BarcodeFieldData code128)
                 {
                     return new ZplBarcode128(text, x, y, code128.Height, moduleWidth, wideBarToNarrowBarWidthRatio, code128.FieldOrientation, hexadecimalIndicator, code128.PrintInterpretationLine, code128.PrintInterpretationLineAboveCode, bottomToTop, useDefaultPosition, code128.Mode);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is CodeEAN13BarcodeFieldData codeEAN13)
+                else if (virtualPrinter.NextElementFieldData is CodeEAN13BarcodeFieldData codeEAN13)
                 {
                     return new ZplBarcodeEan13(text, x, y, codeEAN13.Height, moduleWidth, wideBarToNarrowBarWidthRatio, codeEAN13.FieldOrientation, hexadecimalIndicator, codeEAN13.PrintInterpretationLine, codeEAN13.PrintInterpretationLineAboveCode, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is DataMatrixFieldData dataMatrixFieldData)
+                else if (virtualPrinter.NextElementFieldData is DataMatrixFieldData dataMatrixFieldData)
                 {
                     return new ZplDataMatrix(text, x, y, dataMatrixFieldData.Height, dataMatrixFieldData.QualityLevel, dataMatrixFieldData.FieldOrientation, hexadecimalIndicator, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is Interleaved2of5BarcodeFieldData interleaved2of5)
+                else if (virtualPrinter.NextElementFieldData is Interleaved2of5BarcodeFieldData interleaved2of5)
                 {
                     return new ZplBarcodeInterleaved2of5(text, x, y, interleaved2of5.Height, moduleWidth, wideBarToNarrowBarWidthRatio, interleaved2of5.FieldOrientation, hexadecimalIndicator, interleaved2of5.PrintInterpretationLine, interleaved2of5.PrintInterpretationLineAboveCode, bottomToTop: bottomToTop, useDefaultPosition: useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is MaxiCodeBarcodeFieldData maxiCode)
+                else if (virtualPrinter.NextElementFieldData is MaxiCodeBarcodeFieldData maxiCode)
                 {
                     return new ZplMaxiCode(text, x, y, maxiCode.Mode, maxiCode.Position, maxiCode.Total, hexadecimalIndicator, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is QrCodeBarcodeFieldData qrCode)
+                else if (virtualPrinter.NextElementFieldData is QrCodeBarcodeFieldData qrCode)
                 {
                     (ErrorCorrectionLevel errorCorrection, string parsedText) = this.ParseQrCodeFieldData(qrCode, text);
                     // N.B.: always pass Field Orientation Normal to QR codes; the ZPL II standard does not allow rotation
                     return new ZplQrCode(parsedText, x, y, qrCode.Model, qrCode.MagnificationFactor, errorCorrection, qrCode.MaskValue, FieldOrientation.Normal, hexadecimalIndicator, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is UpcABarcodeFieldData upcA)
+                else if (virtualPrinter.NextElementFieldData is UpcABarcodeFieldData upcA)
                 {
                     return new ZplBarcodeUpcA(text, x, y, upcA.Height, moduleWidth, wideBarToNarrowBarWidthRatio, upcA.FieldOrientation, hexadecimalIndicator, upcA.PrintInterpretationLine, upcA.PrintInterpretationLineAboveCode, upcA.PrintCheckDigit, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is UpcEBarcodeFieldData upcE)
+                else if (virtualPrinter.NextElementFieldData is UpcEBarcodeFieldData upcE)
                 {
                     return new ZplBarcodeUpcE(text, x, y, upcE.Height, moduleWidth, wideBarToNarrowBarWidthRatio, upcE.FieldOrientation, hexadecimalIndicator, upcE.PrintInterpretationLine, upcE.PrintInterpretationLineAboveCode, upcE.PrintCheckDigit, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is UpcExtensionBarcodeFieldData upcExt)
+                else if (virtualPrinter.NextElementFieldData is UpcExtensionBarcodeFieldData upcExt)
                 {
                     return new ZplBarcodeUpcExtension(text, x, y, upcExt.Height, moduleWidth, wideBarToNarrowBarWidthRatio, upcExt.FieldOrientation, hexadecimalIndicator, upcExt.PrintInterpretationLine, upcExt.PrintInterpretationLineAboveCode, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is PDF417FieldData pdf147)
+                else if (virtualPrinter.NextElementFieldData is PDF417FieldData pdf147)
                 {
                     return new ZplPDF417(text, x, y, pdf147.Height, moduleWidth, pdf147.Columns, pdf147.Rows, pdf147.Compact, pdf147.SecurityLevel, pdf147.FieldOrientation, hexadecimalIndicator, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is AztecBarcodeFieldData aztec)
+                else if (virtualPrinter.NextElementFieldData is AztecBarcodeFieldData aztec)
                 {
                     return new ZplAztecBarcode(text, x, y, aztec.MagnificationFactor, aztec.ExtendedChannel, aztec.ErrorControl, aztec.MenuSymbol, aztec.SymbolCount, aztec.IdField, aztec.FieldOrientation, hexadecimalIndicator, bottomToTop, useDefaultPosition);
                 }
-                else if (this.VirtualPrinter.NextElementFieldData is AnsiCodabarFieldData codabar)
+                else if (virtualPrinter.NextElementFieldData is AnsiCodabarFieldData codabar)
                 {
                     return new ZplBarcodeAnsiCodabar(text, codabar.StartCharacter, codabar.StopCharacter, x, y, codabar.Height, moduleWidth, wideBarToNarrowBarWidthRatio, codabar.FieldOrientation, hexadecimalIndicator, codabar.PrintInterpretationLine, codabar.PrintInterpretationLineAboveCode, codabar.CheckDigit, bottomToTop, useDefaultPosition);
                 }
-                else if(this.VirtualPrinter.NextElementFieldData is GraphicSymbolFieldData graphicSymbol)
+                else if(virtualPrinter.NextElementFieldData is GraphicSymbolFieldData graphicSymbol)
                 {
                     return new ZplGraphicSymbol(text, x, y, graphicSymbol.Width, graphicSymbol.Height, graphicSymbol.FieldOrientation, bottomToTop, useDefaultPosition);
                 }
             }
 
-            ZplFont font = this.GetFontFromVirtualPrinter();
-            if (this.VirtualPrinter.NextFont != null)
+            ZplFont font = this.GetFontFromVirtualPrinter(virtualPrinter);
+            if (virtualPrinter.NextFont != null)
             {
-                font = this.GetNextFontFromVirtualPrinter();
+                font = this.GetNextFontFromVirtualPrinter(virtualPrinter);
             }
 
-            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = virtualPrinter.NextElementFieldReverse || virtualPrinter.LabelReverse;
 
-            if (this.VirtualPrinter.NextElementFieldBlock != null)
+            if (virtualPrinter.NextElementFieldBlock != null)
             {
-                int width = this.VirtualPrinter.NextElementFieldBlock.WidthOfTextBlockLine;
-                int maxLineCount = this.VirtualPrinter.NextElementFieldBlock.MaximumNumberOfLinesInTextBlock;
-                TextJustification textJustification = this.VirtualPrinter.NextElementFieldBlock.TextJustification;
-                int lineSpace = this.VirtualPrinter.NextElementFieldBlock.AddOrDeleteSpaceBetweenLines;
-                int hangingIndent = this.VirtualPrinter.NextElementFieldBlock.HangingIndentOfTheSecondAndRemainingLines;
+                int width = virtualPrinter.NextElementFieldBlock.WidthOfTextBlockLine;
+                int maxLineCount = virtualPrinter.NextElementFieldBlock.MaximumNumberOfLinesInTextBlock;
+                TextJustification textJustification = virtualPrinter.NextElementFieldBlock.TextJustification;
+                int lineSpace = virtualPrinter.NextElementFieldBlock.AddOrDeleteSpaceBetweenLines;
+                int hangingIndent = virtualPrinter.NextElementFieldBlock.HangingIndentOfTheSecondAndRemainingLines;
 
                 return new ZplFieldBlock(text, x, y, width, font, maxLineCount, lineSpace, textJustification, hangingIndent, hexadecimalIndicator: hexadecimalIndicator, reversePrint: reversePrint, bottomToTop: bottomToTop, useDefaultPosition: useDefaultPosition);
             }
@@ -229,22 +229,22 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             return (errorCorrection, parsedText);
         }
 
-        private ZplFont GetFontFromVirtualPrinter()
+        private ZplFont GetFontFromVirtualPrinter(VirtualPrinter virtualPrinter)
         {
-            int fontWidth = this.VirtualPrinter.FontWidth;
-            int fontHeight = this.VirtualPrinter.FontHeight;
-            string fontName = this.VirtualPrinter.FontName;
-            FieldOrientation fieldOrientation = this.VirtualPrinter.FieldOrientation;
+            int fontWidth = virtualPrinter.FontWidth;
+            int fontHeight = virtualPrinter.FontHeight;
+            string fontName = virtualPrinter.FontName;
+            FieldOrientation fieldOrientation = virtualPrinter.FieldOrientation;
 
             return new ZplFont(fontWidth, fontHeight, fontName, fieldOrientation);
         }
 
-        private ZplFont GetNextFontFromVirtualPrinter()
+        private ZplFont GetNextFontFromVirtualPrinter(VirtualPrinter virtualPrinter)
         {
-            int fontWidth = this.VirtualPrinter.NextFont.FontWidth;
-            int fontHeight = this.VirtualPrinter.NextFont.FontHeight;
-            string fontName = this.VirtualPrinter.NextFont.FontName;
-            FieldOrientation fieldOrientation = this.VirtualPrinter.NextFont.FieldOrientation;
+            int fontWidth = virtualPrinter.NextFont.FontWidth;
+            int fontHeight = virtualPrinter.NextFont.FontHeight;
+            string fontName = virtualPrinter.NextFont.FontName;
+            FieldOrientation fieldOrientation = virtualPrinter.NextFont.FieldOrientation;
 
             return new ZplFont(fontWidth, fontHeight, fontName, fieldOrientation);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldHexadecimalZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldHexadecimalZplCommandAnalyzer.cs
@@ -4,10 +4,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldHexadecimalZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldHexadecimalZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FH", virtualPrinter) { }
+        public FieldHexadecimalZplCommandAnalyzer() : base("^FH") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             char indicator = '_';
             string[] zplDataParts = this.SplitCommand(zplCommand);
@@ -16,7 +16,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 indicator = zplDataParts[0][0];
             }
 
-            this.VirtualPrinter.SetNextElementFieldHexadecimalIndicator(indicator);
+            virtualPrinter.SetNextElementFieldHexadecimalIndicator(indicator);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldNumberCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldNumberCommandAnalyzer.cs
@@ -4,10 +4,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldNumberCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldNumberCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FN", virtualPrinter) { }
+        public FieldNumberCommandAnalyzer() : base("^FN") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -19,7 +19,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 fieldNumber = tmpint;
             }
 
-            this.VirtualPrinter.SetNextFieldNumber(fieldNumber);
+            virtualPrinter.SetNextFieldNumber(fieldNumber);
             return null;
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOrientationZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOrientationZplCommandAnalyzer.cs
@@ -5,22 +5,22 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldOrientationZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldOrientationZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FW", virtualPrinter) { }
+        public FieldOrientationZplCommandAnalyzer() : base("^FW") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
             if (zplDataParts.Length > 0)
             {
-                FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
-                this.VirtualPrinter.SetFieldOrientation(fieldOrientation);
+                FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
+                virtualPrinter.SetFieldOrientation(fieldOrientation);
             }
 
             if (zplDataParts.Length > 1)
             {
-                FieldJustification fieldJustification = this.ConvertFieldJustification(zplDataParts[1]);
-                this.VirtualPrinter.SetFieldJustification(fieldJustification);
+                FieldJustification fieldJustification = this.ConvertFieldJustification(zplDataParts[1], virtualPrinter);
+                virtualPrinter.SetFieldJustification(fieldJustification);
             }
 
             return null;

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOriginZplCommandAnalzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldOriginZplCommandAnalzer.cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldOriginZplCommandAnalzer : ZplCommandAnalyzerBase
     {
-        public FieldOriginZplCommandAnalzer(VirtualPrinter virtualPrinter) : base("^FO", virtualPrinter) { }
+        public FieldOriginZplCommandAnalzer() : base("^FO") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -23,7 +23,6 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 x = decimal.ToInt32(tmpdec);
             }
 
-
             if (zplDataParts.Length > 1 &&
                 decimal.TryParse(zplDataParts[1], out tmpdec) &&
                 int.MinValue <= tmpdec && tmpdec <= int.MaxValue)
@@ -33,17 +32,17 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             if (zplDataParts.Length > 2)
             {
-                FieldJustification fieldJustification = this.ConvertFieldJustification(zplDataParts[2]);
-                this.VirtualPrinter.SetNextElementFieldJustification(fieldJustification);
+                FieldJustification fieldJustification = this.ConvertFieldJustification(zplDataParts[2], virtualPrinter);
+                virtualPrinter.SetNextElementFieldJustification(fieldJustification);
             }
 
-            if (this.VirtualPrinter.LabelHomePosition != null)
+            if (virtualPrinter.LabelHomePosition != null)
             {
-                x += this.VirtualPrinter.LabelHomePosition.X;
-                y += this.VirtualPrinter.LabelHomePosition.Y;
+                x += virtualPrinter.LabelHomePosition.X;
+                y += virtualPrinter.LabelHomePosition.Y;
             }
 
-            this.VirtualPrinter.SetNextElementPosition(x, y);
+            virtualPrinter.SetNextElementPosition(x, y);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldReversePrintZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldReversePrintZplCommandAnalyzer.cs
@@ -4,12 +4,12 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldReversePrintZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FR", virtualPrinter) { }
+        public FieldReversePrintZplCommandAnalyzer() : base("^FR") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
-            this.VirtualPrinter.SetNextElementFieldReverse();
+            virtualPrinter.SetNextElementFieldReverse();
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldSeparatorZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldSeparatorZplCommandAnalyzer.cs
@@ -4,36 +4,32 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldSeparatorZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        private readonly ZplCommandAnalyzerBase fieldDataAnalyzer;
+        private static readonly FieldDataZplCommandAnalyzer fieldDataAnalyzer = new();
 
-        public FieldSeparatorZplCommandAnalyzer(VirtualPrinter virtualPrinter, ZplCommandAnalyzerBase fieldDataAnalyzer)
-            : base("^FS", virtualPrinter)
-        {
-            this.fieldDataAnalyzer = fieldDataAnalyzer;
-        }
+        public FieldSeparatorZplCommandAnalyzer() : base("^FS") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             // If next field number has been set and was not consumed by a field data
             // it has to be stored as a command so that it is handled when merging formats
             ZplElementBase element = null;
-            int? fieldNumber = this.VirtualPrinter.NextFieldNumber;
+            int? fieldNumber = virtualPrinter.NextFieldNumber;
             if (fieldNumber.HasValue)
             {
-                this.VirtualPrinter.ClearNextFieldNumber();
-                ZplElementBase dataElement = this.fieldDataAnalyzer.Analyze(zplCommand);
+                virtualPrinter.ClearNextFieldNumber();
+                ZplElementBase dataElement = fieldDataAnalyzer.Analyze(zplCommand, virtualPrinter, printerStorage);
                 element = new ZplFieldNumber(fieldNumber.Value, dataElement);
             }
 
-            this.VirtualPrinter.ClearNextElementPosition();
-            this.VirtualPrinter.ClearNextElementFieldBlock();
-            this.VirtualPrinter.ClearNextElementFieldData();
-            this.VirtualPrinter.ClearNextElementFieldReverse();
-            this.VirtualPrinter.ClearNextElementFieldHexadecimalIndicator();
-            this.VirtualPrinter.ClearNextElementFieldJustification();
-            this.VirtualPrinter.ClearNextFont();
-            this.VirtualPrinter.ClearComments();
+            virtualPrinter.ClearNextElementPosition();
+            virtualPrinter.ClearNextElementFieldBlock();
+            virtualPrinter.ClearNextElementFieldData();
+            virtualPrinter.ClearNextElementFieldReverse();
+            virtualPrinter.ClearNextElementFieldHexadecimalIndicator();
+            virtualPrinter.ClearNextElementFieldJustification();
+            virtualPrinter.ClearNextFont();
+            virtualPrinter.ClearComments();
 
             return element;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldTypesetZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldTypesetZplCommandAnalyzer.cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class FieldTypesetZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public FieldTypesetZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^FT", virtualPrinter) { }
+        public FieldTypesetZplCommandAnalyzer() : base("^FT") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -58,17 +58,17 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 
             if (zplDataParts.Length > 2)
             {
-                FieldJustification fieldJustification = this.ConvertFieldJustification(zplDataParts[2]);
-                this.VirtualPrinter.SetNextElementFieldJustification(fieldJustification);
+                FieldJustification fieldJustification = this.ConvertFieldJustification(zplDataParts[2], virtualPrinter);
+                virtualPrinter.SetNextElementFieldJustification(fieldJustification);
             }
 
-            if (this.VirtualPrinter.LabelHomePosition != null)
+            if (virtualPrinter.LabelHomePosition != null)
             {
-                x += this.VirtualPrinter.LabelHomePosition.X;
-                y += this.VirtualPrinter.LabelHomePosition.Y;
+                x += virtualPrinter.LabelHomePosition.X;
+                y += virtualPrinter.LabelHomePosition.Y;
             }
 
-            this.VirtualPrinter.SetNextElementPosition(x, y, true, useDefaultPosition);
+            virtualPrinter.SetNextElementPosition(x, y, true, useDefaultPosition);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldVarialbleZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/FieldVarialbleZplCommandAnalyzer.cs
@@ -9,6 +9,6 @@
     // Subsequent labels only require FV to draw the variable parts.
     public class FieldVariableZplCommandAnalyzer : FieldDataZplCommandAnalyzer
     {
-        public FieldVariableZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base(virtualPrinter, "^FV") { }
+        public FieldVariableZplCommandAnalyzer() : base("^FV") { }
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicBoxZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicBoxZplCommandAnalyzer.cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicBoxZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicBoxZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GB", virtualPrinter) { }
+        public GraphicBoxZplCommandAnalyzer() : base("^GB") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int tmpint;
             int width = 1;
@@ -22,13 +22,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             string[] zplDataParts = this.SplitCommand(zplCommand);
@@ -62,7 +62,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 cornerRounding = tmpint;
             }
 
-            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = virtualPrinter.NextElementFieldReverse || virtualPrinter.LabelReverse;
 
             return new ZplGraphicBox(x, y, width, height, borderThickness, lineColor, cornerRounding, reversePrint, bottomToTop, useDefaultPosition);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicCircleZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicCircleZplCommandAnalyzer.cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicCircleZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicCircleZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GC", virtualPrinter) { }
+        public GraphicCircleZplCommandAnalyzer() : base("^GC") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int tmpint;
             int circleDiameter = 3;
@@ -20,13 +20,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             string[] zplDataParts = this.SplitCommand(zplCommand);
@@ -47,7 +47,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 lineColor = lineColorTemp == "W" ? LineColor.White : LineColor.Black;
             }
 
-            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = virtualPrinter.NextElementFieldReverse || virtualPrinter.LabelReverse;
 
             return new ZplGraphicCircle(x, y, circleDiameter, borderThickness, lineColor, reversePrint, bottomToTop, useDefaultPosition);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicDiagonalLineZplCommandAnalyzer .cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicDiagonalLineZplCommandAnalyzer .cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicDiagonalLineZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicDiagonalLineZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GD", virtualPrinter) { }
+        public GraphicDiagonalLineZplCommandAnalyzer() : base("^GD") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int tmpint;
             int width = 3;
@@ -22,13 +22,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             string[] zplDataParts = this.SplitCommand(zplCommand);
@@ -66,7 +66,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 }
             }
 
-            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = virtualPrinter.NextElementFieldReverse || virtualPrinter.LabelReverse;
 
             return new ZplGraphicDiagonalLine(x, y, width, height, borderThickness, lineColor, rightLeaningDiagonal, reversePrint, bottomToTop, useDefaultPosition);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicEllipseZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicEllipseZplCommandAnalyzer.cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicEllipseZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicEllipseZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GE", virtualPrinter) { }
+        public GraphicEllipseZplCommandAnalyzer() : base("^GE") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int tmpint;
             int width = 1;
@@ -21,13 +21,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             string[] zplDataParts = this.SplitCommand(zplCommand);
@@ -56,7 +56,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 lineColor = lineColorTemp == "W" ? LineColor.White : LineColor.Black;
             }
 
-            bool reversePrint = this.VirtualPrinter.NextElementFieldReverse || this.VirtualPrinter.LabelReverse;
+            bool reversePrint = virtualPrinter.NextElementFieldReverse || virtualPrinter.LabelReverse;
 
             return new ZplGraphicEllipse(x, y, width, height, borderThickness, lineColor, reversePrint, bottomToTop, useDefaultPosition);
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicFieldZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicFieldZplCommandAnalyzer.cs
@@ -7,10 +7,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicFieldZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicFieldZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GF", virtualPrinter) { }
+        public GraphicFieldZplCommandAnalyzer() : base("^GF") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int tmpint;
             int binaryByteCount = 0;
@@ -22,13 +22,13 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             string[] zplDataParts = this.SplitCommand(zplCommand);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicSymbolZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/GraphicSymbolZplCommandAnalyzer.cs
@@ -6,18 +6,18 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class GraphicSymbolZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public GraphicSymbolZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^GS", virtualPrinter) { }
+        public GraphicSymbolZplCommandAnalyzer() : base("^GS") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
-            int height = this.VirtualPrinter.FontHeight;
-            int width = this.VirtualPrinter.FontWidth;
+            int height = virtualPrinter.FontHeight;
+            int width = virtualPrinter.FontWidth;
 
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
@@ -30,7 +30,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new GraphicSymbolFieldData
+            virtualPrinter.SetNextElementFieldData(new GraphicSymbolFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/IZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/IZplCommandAnalyzer.cs
@@ -18,7 +18,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         /// Analyzes the command a returns the corresponding ZPL Element.
         /// </summary>
         /// <param name="zplCommand">The command to analyze.</param>
+        /// <param name="virtualPrinter">The <see cref="VirtualPrinter"/>.</param>
+        /// <param name="printerStorage">The <see cref="IPrinterStorage"/>.</param>
         /// <returns></returns>
-        ZplElementBase Analyze(string zplCommand);
+        ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage);
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ImageMoveZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ImageMoveZplCommandAnalyzer.cs
@@ -4,23 +4,23 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class ImageMoveZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public ImageMoveZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^IM", virtualPrinter) { }
+        public ImageMoveZplCommandAnalyzer() : base("^IM") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int x = 0;
             int y = 0;
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
 
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             string zplCommandData = zplCommand.Substring(this.PrinterCommandPrefix.Length);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Interleaved2of5BarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/Interleaved2of5BarcodeZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -6,17 +6,17 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class Interleaved2of5BarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public Interleaved2of5BarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B2", virtualPrinter) { }
+        public Interleaved2of5BarcodeZplCommandAnalyzer() : base("^B2") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
             bool calculateAndPrintMod10CheckDigit = false;
@@ -42,7 +42,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new Interleaved2of5BarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new Interleaved2of5BarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelHomeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelHomeZplCommandAnalyzer.cs
@@ -4,10 +4,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class LabelHomeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public LabelHomeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LH", virtualPrinter) { }
+        public LabelHomeZplCommandAnalyzer() : base("^LH") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -25,7 +25,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 y = tmpint;
             }
 
-            this.VirtualPrinter.SetLabelHome(x, y);
+            virtualPrinter.SetLabelHome(x, y);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelReversePrintZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/LabelReversePrintZplCommandAnalyzer.cs
@@ -4,10 +4,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class LabelReversePrintZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public LabelReversePrintZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^LR", virtualPrinter) { }
+        public LabelReversePrintZplCommandAnalyzer() : base("^LR") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -18,7 +18,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 reverse = this.ConvertBoolean(zplDataParts[0]);
             }
 
-            this.VirtualPrinter.SetLabelReverse(reverse);
+            virtualPrinter.SetLabelReverse(reverse);
             return null;
         }
     }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/MaxiCodeBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/MaxiCodeBarcodeZplCommandAnalyzer.cs
@@ -5,10 +5,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class MaxiCodeBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public MaxiCodeBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BD", virtualPrinter) { }
+        public MaxiCodeBarcodeZplCommandAnalyzer() : base("^BD") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -32,7 +32,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 total = tmpint;
             }
 
-            this.VirtualPrinter.SetNextElementFieldData(new MaxiCodeBarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new MaxiCodeBarcodeFieldData
             {
                 Mode = mode,
                 Position = position,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/PDF417BarcodeCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/PDF417BarcodeCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Models;
 
@@ -9,9 +9,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class PDF417ZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public PDF417ZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B7", virtualPrinter) { }
+        public PDF417ZplCommandAnalyzer() : base("^B7") { }
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
@@ -28,9 +28,9 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
              * compact
             */
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
                 height = tmpint;
@@ -71,7 +71,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             }
 
             //The field data are processing in the FieldDataZplCommandAnalyzer
-            this.VirtualPrinter.SetNextElementFieldData(new PDF417FieldData
+            virtualPrinter.SetNextElementFieldData(new PDF417FieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/QrCodeBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/QrCodeBarcodeZplCommandAnalyzer.cs
@@ -6,14 +6,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class QrCodeBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public QrCodeBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BQ", virtualPrinter) { }
+        public QrCodeBarcodeZplCommandAnalyzer() : base("^BQ") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
             int model = 2;
@@ -47,7 +47,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 maskValue = tmpint;
             }
 
-            this.VirtualPrinter.SetNextElementFieldData(new QrCodeBarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new QrCodeBarcodeFieldData
             {
                 Model = model,
                 FieldOrientation = fieldOrientation,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallFormatCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallFormatCommandAnalyzer.cs
@@ -4,10 +4,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class RecallFormatCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public RecallFormatCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^XF", virtualPrinter) { }
+        public RecallFormatCommandAnalyzer() : base("^XF") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string formatName = zplCommand.Substring(this.PrinterCommandPrefix.Length);
 

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallGraphicZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/RecallGraphicZplCommandAnalyzer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label.Elements;
+﻿using BinaryKits.Zpl.Label.Elements;
 
 using System.Text.RegularExpressions;
 
@@ -8,22 +8,22 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     {
         private static readonly Regex commandRegex = new(@"^\^XG(\w:)?(.*?\..+?)(?:,(\d*))?(?:,(\d*))?$", RegexOptions.Compiled);
 
-        public RecallGraphicZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^XG", virtualPrinter) { }
+        public RecallGraphicZplCommandAnalyzer() : base("^XG") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             int x = 0;
             int y = 0;
             bool bottomToTop = false;
             bool useDefaultPosition = false;
 
-            if (this.VirtualPrinter.NextElementPosition != null)
+            if (virtualPrinter.NextElementPosition != null)
             {
-                x = this.VirtualPrinter.NextElementPosition.X;
-                y = this.VirtualPrinter.NextElementPosition.Y;
-                bottomToTop = this.VirtualPrinter.NextElementPosition.CalculateFromBottom;
-                useDefaultPosition = this.VirtualPrinter.NextElementPosition.UseDefaultPosition;
+                x = virtualPrinter.NextElementPosition.X;
+                y = virtualPrinter.NextElementPosition.Y;
+                bottomToTop = virtualPrinter.NextElementPosition.CalculateFromBottom;
+                useDefaultPosition = virtualPrinter.NextElementPosition.UseDefaultPosition;
             }
 
             Match commandMatch = commandRegex.Match(zplCommand);

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ScalableBitmappedFontZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ScalableBitmappedFontZplCommandAnalyzer.cs
@@ -5,16 +5,16 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class ScalableBitmappedFontZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public ScalableBitmappedFontZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^A", virtualPrinter) { }
+        public ScalableBitmappedFontZplCommandAnalyzer() : base("^A") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string fontName = zplCommand[this.PrinterCommandPrefix.Length].ToString();
 
             string[] zplDataParts = this.SplitCommand(zplCommand, 1);
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
 
             int tmpint;
             int? parsedHeight = null;
@@ -30,10 +30,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 parsedWidth = tmpint;
             }
 
-            int fontHeight = parsedHeight ?? this.VirtualPrinter.FontHeight;
-            int fontWidth = parsedWidth ?? this.VirtualPrinter.FontWidth;
+            int fontHeight = parsedHeight ?? virtualPrinter.FontHeight;
+            int fontWidth = parsedWidth ?? virtualPrinter.FontWidth;
 
-            this.VirtualPrinter.SetNextFont(fontName, fieldOrientation, fontWidth, fontHeight);
+            virtualPrinter.SetNextFont(fontName, fieldOrientation, fontWidth, fontHeight);
 
             return null;
         }

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/UpcABarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/UpcABarcodeZplCommandAnalyzer.cs
@@ -6,20 +6,20 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class UpcABarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public UpcABarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BU", virtualPrinter) { }
+        public UpcABarcodeZplCommandAnalyzer() : base("^BU") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
             bool printCheckDigit = true;
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
                 height = tmpint;
@@ -40,7 +40,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 printCheckDigit = this.ConvertBoolean(zplDataParts[4]);
             }
 
-            this.VirtualPrinter.SetNextElementFieldData(new UpcABarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new UpcABarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/UpcEBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/UpcEBarcodeZplCommandAnalyzer.cs
@@ -6,20 +6,20 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class UpcEBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public UpcEBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^B9", virtualPrinter) { }
+        public UpcEBarcodeZplCommandAnalyzer() : base("^B9") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = false;
             bool printCheckDigit = true;
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
                 height = tmpint;
@@ -40,7 +40,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 printCheckDigit = this.ConvertBoolean(zplDataParts[4]);
             }
 
-            this.VirtualPrinter.SetNextElementFieldData(new UpcEBarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new UpcEBarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/UpcExtensionBarcodeZplCommandAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/UpcExtensionBarcodeZplCommandAnalyzer.cs
@@ -6,19 +6,19 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
 {
     public class UpcExtensionBarcodeZplCommandAnalyzer : ZplCommandAnalyzerBase
     {
-        public UpcExtensionBarcodeZplCommandAnalyzer(VirtualPrinter virtualPrinter) : base("^BS", virtualPrinter) { }
+        public UpcExtensionBarcodeZplCommandAnalyzer() : base("^BS") { }
 
         ///<inheritdoc/>
-        public override ZplElementBase Analyze(string zplCommand)
+        public override ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage)
         {
             string[] zplDataParts = this.SplitCommand(zplCommand);
 
             int tmpint;
-            int height = this.VirtualPrinter.BarcodeInfo.Height;
+            int height = virtualPrinter.BarcodeInfo.Height;
             bool printInterpretationLine = true;
             bool printInterpretationLineAboveCode = true;
 
-            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0]);
+            FieldOrientation fieldOrientation = this.ConvertFieldOrientation(zplDataParts[0], virtualPrinter);
             if (zplDataParts.Length > 1 && int.TryParse(zplDataParts[1], out tmpint))
             {
                 height = tmpint;
@@ -34,7 +34,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 printInterpretationLineAboveCode = this.ConvertBoolean(zplDataParts[3], "Y");
             }
 
-            this.VirtualPrinter.SetNextElementFieldData(new UpcExtensionBarcodeFieldData
+            virtualPrinter.SetNextElementFieldData(new UpcExtensionBarcodeFieldData
             {
                 FieldOrientation = fieldOrientation,
                 Height = height,

--- a/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/CommandAnalyzers/ZplCommandAnalyzerBase.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 
 namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
@@ -6,12 +6,10 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
     public abstract class ZplCommandAnalyzerBase : IZplCommandAnalyzer
     {
         public string PrinterCommandPrefix { get; private set; }
-        public VirtualPrinter VirtualPrinter { get; private set; }
 
-        public ZplCommandAnalyzerBase(string prefix, VirtualPrinter virtualPrinter)
+        public ZplCommandAnalyzerBase(string prefix)
         {
             this.PrinterCommandPrefix = prefix;
-            this.VirtualPrinter = virtualPrinter;
         }
 
         ///<inheritdoc/>
@@ -21,7 +19,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
         }
 
         ///<inheritdoc/>
-        public abstract ZplElementBase Analyze(string zplCommand);
+        public abstract ZplElementBase Analyze(string zplCommand, VirtualPrinter virtualPrinter, IPrinterStorage printerStorage);
 
         protected string[] SplitCommand(string zplCommand, int dataStartIndex = 0)
         {
@@ -29,7 +27,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             return zplCommandData.Trim().Split(',');
         }
 
-        protected FieldOrientation ConvertFieldOrientation(string fieldOrientation)
+        protected FieldOrientation ConvertFieldOrientation(string fieldOrientation, VirtualPrinter virtualPrinter)
         {
             return fieldOrientation switch
             {
@@ -37,7 +35,7 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
                 "R" => FieldOrientation.Rotated90,
                 "I" => FieldOrientation.Rotated180,
                 "B" => FieldOrientation.Rotated270,
-                _ => this.VirtualPrinter.FieldOrientation,
+                _ => virtualPrinter.FieldOrientation,
             };
         }
 
@@ -55,14 +53,14 @@ namespace BinaryKits.Zpl.Viewer.CommandAnalyzers
             };
         }
 
-        protected FieldJustification ConvertFieldJustification(string fieldJustification)
+        protected FieldJustification ConvertFieldJustification(string fieldJustification,VirtualPrinter virtualPrinter)
         {
             return fieldJustification switch
             {
                 "0" => FieldJustification.Left,
                 "1" => FieldJustification.Right,
                 "2" => FieldJustification.Auto,
-                _ => this.VirtualPrinter.FieldJustification,
+                _ => virtualPrinter.FieldJustification,
             };
         }
 

--- a/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplAnalyzer.cs
@@ -14,11 +14,60 @@ namespace BinaryKits.Zpl.Viewer
     {
         private static readonly Regex verticalWhitespaceRegex = new(@"[\n\v\f\r]", RegexOptions.Compiled);
 
+        /// <summary>
+        /// The array of <see cref="IZplCommandAnalyzer"/> to analyze ZPL text
+        /// </summary>
+        public static IZplCommandAnalyzer[] Analyzers { get; } = [
+            new FieldDataZplCommandAnalyzer(),
+            new AztecBarcodeZplCommandAnalyzer(),
+            new BarCodeFieldDefaultZplCommandAnalyzer(),
+            new ChangeAlphanumericDefaultFontZplCommandAnalyzer(),
+            new ChangeInternationalFontCommandAnalyzer(),
+            new Code39BarcodeZplCommandAnalyzer(),
+            new Code93BarcodeZplCommandAnalyzer(),
+            new Code128BarcodeZplCommandAnalyzer(),
+            new CodeEAN13BarcodeZplCommandAnalyzer(),
+            new CommentZplCommandAnalyzer(),
+            new DataMatrixZplCommandAnalyzer(),
+            new DownloadFormatCommandAnalyzer(),
+            new DownloadGraphicsZplCommandAnalyzer(),
+            new DownloadObjectsZplCommandAnaylzer(),
+            new FieldBlockZplCommandAnalyzer(),
+            new FieldHexadecimalZplCommandAnalyzer(),
+            new FieldOrientationZplCommandAnalyzer(),
+            new FieldNumberCommandAnalyzer(),
+            new FieldVariableZplCommandAnalyzer(),
+            new FieldReversePrintZplCommandAnalyzer(),
+            new LabelReversePrintZplCommandAnalyzer(),
+            new FieldSeparatorZplCommandAnalyzer(),
+            new FieldTypesetZplCommandAnalyzer(),
+            new FieldOriginZplCommandAnalzer(),
+            new GraphicBoxZplCommandAnalyzer(),
+            new GraphicCircleZplCommandAnalyzer(),
+            new GraphicDiagonalLineZplCommandAnalyzer(),
+            new GraphicEllipseZplCommandAnalyzer(),
+            new GraphicFieldZplCommandAnalyzer(),
+            new GraphicSymbolZplCommandAnalyzer(),
+            new Interleaved2of5BarcodeZplCommandAnalyzer(),
+            new ImageMoveZplCommandAnalyzer(),
+            new LabelHomeZplCommandAnalyzer(),
+            new MaxiCodeBarcodeZplCommandAnalyzer(),
+            new QrCodeBarcodeZplCommandAnalyzer(),
+            new UpcABarcodeZplCommandAnalyzer(),
+            new UpcEBarcodeZplCommandAnalyzer(),
+            new UpcExtensionBarcodeZplCommandAnalyzer(),
+            new PDF417ZplCommandAnalyzer(),
+            new RecallFormatCommandAnalyzer(),
+            new RecallGraphicZplCommandAnalyzer(),
+            new ScalableBitmappedFontZplCommandAnalyzer(),
+            new AnsiCodabarBarcodeZplCommandAnalyzer(),
+        ];
+
         private readonly VirtualPrinter virtualPrinter;
         private readonly IPrinterStorage printerStorage;
         private readonly IFormatMerger formatMerger;
-        private readonly string labelStartCommand = "^XA";
-        private readonly string labelEndCommand = "^XZ";
+        private const string labelStartCommand = "^XA";
+        private const string labelEndCommand = "^XZ";
 
         public ZplAnalyzer(IPrinterStorage printerStorage, IFormatMerger formatMerger = null)
         {
@@ -33,53 +82,6 @@ namespace BinaryKits.Zpl.Viewer
             List<string> unknownCommands = [];
             List<string> errors = [];
 
-            FieldDataZplCommandAnalyzer fieldDataAnalyzer = new(this.virtualPrinter);
-            List<IZplCommandAnalyzer> elementAnalyzers = [
-                fieldDataAnalyzer,
-                new AztecBarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new BarCodeFieldDefaultZplCommandAnalyzer(this.virtualPrinter),
-                new ChangeAlphanumericDefaultFontZplCommandAnalyzer(this.virtualPrinter),
-                new ChangeInternationalFontCommandAnalyzer(this.virtualPrinter),
-                new Code39BarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new Code93BarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new Code128BarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new CodeEAN13BarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new CommentZplCommandAnalyzer(this.virtualPrinter),
-                new DataMatrixZplCommandAnalyzer(this.virtualPrinter),
-                new DownloadFormatCommandAnalyzer(this.virtualPrinter),
-                new DownloadGraphicsZplCommandAnalyzer(this.virtualPrinter, this.printerStorage),
-                new DownloadObjectsZplCommandAnaylzer(this.virtualPrinter, this.printerStorage),
-                new FieldBlockZplCommandAnalyzer(this.virtualPrinter),
-                new FieldHexadecimalZplCommandAnalyzer(this.virtualPrinter),
-                new FieldOrientationZplCommandAnalyzer(this.virtualPrinter),
-                new FieldNumberCommandAnalyzer(this.virtualPrinter),
-                new FieldVariableZplCommandAnalyzer(this.virtualPrinter),
-                new FieldReversePrintZplCommandAnalyzer(this.virtualPrinter),
-                new LabelReversePrintZplCommandAnalyzer(this.virtualPrinter),
-                new FieldSeparatorZplCommandAnalyzer(this.virtualPrinter, fieldDataAnalyzer),
-                new FieldTypesetZplCommandAnalyzer(this.virtualPrinter),
-                new FieldOriginZplCommandAnalzer(this.virtualPrinter),
-                new GraphicBoxZplCommandAnalyzer(this.virtualPrinter),
-                new GraphicCircleZplCommandAnalyzer(this.virtualPrinter),
-                new GraphicDiagonalLineZplCommandAnalyzer(this.virtualPrinter),
-                new GraphicEllipseZplCommandAnalyzer(this.virtualPrinter),
-                new GraphicFieldZplCommandAnalyzer(this.virtualPrinter),
-                new GraphicSymbolZplCommandAnalyzer(this.virtualPrinter),
-                new Interleaved2of5BarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new ImageMoveZplCommandAnalyzer(this.virtualPrinter),
-                new LabelHomeZplCommandAnalyzer(this.virtualPrinter),
-                new MaxiCodeBarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new QrCodeBarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new UpcABarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new UpcEBarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new UpcExtensionBarcodeZplCommandAnalyzer(this.virtualPrinter),
-                new PDF417ZplCommandAnalyzer(this.virtualPrinter),
-                new RecallFormatCommandAnalyzer(this.virtualPrinter),
-                new RecallGraphicZplCommandAnalyzer(this.virtualPrinter),
-                new ScalableBitmappedFontZplCommandAnalyzer(this.virtualPrinter),
-                new AnsiCodabarBarcodeZplCommandAnalyzer(this.virtualPrinter),
-            ];
-
             List<LabelInfo> labelInfos = [];
 
             List<ZplElementBase> elements = [];
@@ -87,14 +89,14 @@ namespace BinaryKits.Zpl.Viewer
             {
                 string currentCommand = zplCommands[i];
 
-                if (this.labelStartCommand.Equals(currentCommand.Trim(), StringComparison.OrdinalIgnoreCase))
+                if (labelStartCommand.Equals(currentCommand.Trim(), StringComparison.OrdinalIgnoreCase))
                 {
                     elements.Clear();
                     this.virtualPrinter.ClearNextDownloadFormatName();
                     continue;
                 }
 
-                if (this.labelEndCommand.Equals(currentCommand.Trim(), StringComparison.OrdinalIgnoreCase))
+                if (labelEndCommand.Equals(currentCommand.Trim(), StringComparison.OrdinalIgnoreCase))
                 {
                     labelInfos.Add(new LabelInfo
                     {
@@ -104,7 +106,7 @@ namespace BinaryKits.Zpl.Viewer
                     continue;
                 }
 
-                IEnumerable<IZplCommandAnalyzer> validAnalyzers = elementAnalyzers.Where(o => o.CanAnalyze(currentCommand));
+                IEnumerable<IZplCommandAnalyzer> validAnalyzers = Analyzers.Where(o => o.CanAnalyze(currentCommand));
 
                 if (!validAnalyzers.Any())
                 {
@@ -114,7 +116,7 @@ namespace BinaryKits.Zpl.Viewer
 
                 try
                 {
-                    elements.AddRange(validAnalyzers.Select(analyzer => analyzer.Analyze(currentCommand)).Where(o => o != null));
+                    elements.AddRange(validAnalyzers.Select(analyzer => analyzer.Analyze(currentCommand, this.virtualPrinter, this.printerStorage)).Where(o => o != null));
                 }
                 catch (Exception exception)
                 {

--- a/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ZplElementDrawer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.ElementDrawers;
 using BinaryKits.Zpl.Viewer.Helpers;
@@ -14,19 +14,10 @@ namespace BinaryKits.Zpl.Viewer
 {
     public class ZplElementDrawer
     {
-        private static readonly int pdfDpi = 72;
-        private static readonly float zplDpi = 203.2f;
-        private static readonly float pdfScaleFactor = pdfDpi / zplDpi;
-
-        private readonly DrawerOptions drawerOptions;
-        private readonly IPrinterStorage printerStorage;
-        private readonly IElementDrawer[] elementDrawers;
-
-        public ZplElementDrawer(IPrinterStorage printerStorage, DrawerOptions drawerOptions = null)
-        {
-            this.drawerOptions = drawerOptions ?? new DrawerOptions();
-            this.printerStorage = printerStorage;
-            this.elementDrawers = [
+        /// <summary>
+        /// The array of <see cref="IElementDrawer"/> to draw <see cref="ZplElementBase"/>
+        /// </summary>
+        public static IElementDrawer[] ElementDrawers { get; } = [
                 new AztecBarcodeElementDrawer(),
                 new Barcode128ElementDrawer(),
                 new Barcode39ElementDrawer(),
@@ -52,6 +43,18 @@ namespace BinaryKits.Zpl.Viewer
                 new TextFieldElementDrawer(),
                 new BarcodeAnsiCodabarElementDrawer(),
             ];
+
+        private static readonly int pdfDpi = 72;
+        private static readonly float zplDpi = 203.2f;
+        private static readonly float pdfScaleFactor = pdfDpi / zplDpi;
+
+        private readonly DrawerOptions drawerOptions;
+        private readonly IPrinterStorage printerStorage;
+
+        public ZplElementDrawer(IPrinterStorage printerStorage, DrawerOptions drawerOptions = null)
+        {
+            this.drawerOptions = drawerOptions ?? new DrawerOptions();
+            this.printerStorage = printerStorage;
         }
 
         /// <summary>
@@ -145,7 +148,7 @@ namespace BinaryKits.Zpl.Viewer
                     continue;
                 }
 
-                IElementDrawer drawer = this.elementDrawers.SingleOrDefault(o => o.CanDraw(element));
+                IElementDrawer drawer = ElementDrawers.SingleOrDefault(o => o.CanDraw(element));
                 if (drawer == null)
                 {
                     continue;
@@ -302,7 +305,7 @@ namespace BinaryKits.Zpl.Viewer
                     continue;
                 }
 
-                IElementDrawer drawer = this.elementDrawers.SingleOrDefault(o => o.CanDraw(element));
+                IElementDrawer drawer = ElementDrawers.SingleOrDefault(o => o.CanDraw(element));
                 if (drawer == null)
                 {
                     continue;


### PR DESCRIPTION
This PR avoids the allocation per-call of both analyzers and drawers.

In order to do so, both analyzers and drawers must be stateless.
State is passed in `Analyze` and `Draw` interface calls.