### PR TITLE
Ensure font fallback is to "font" and not just to "typeface"

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode128ElementDrawer.cs
@@ -77,7 +77,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 {
                     // TODO: use font 0, auto scale for Mode D
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     this.DrawInterpretationLine(interpretation, labelFont, x, y, resizedImage.Width, resizedImage.Height, barcode.FieldOrigin != null, barcode.FieldOrientation, barcode.PrintInterpretationLineAboveCode, options);
                 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode39ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode39ElementDrawer.cs
@@ -55,7 +55,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     this.DrawInterpretationLine(interpretation, labelFont, x, y, resizedImage.Width, resizedImage.Height, barcode.FieldOrigin != null, barcode.FieldOrientation, barcode.PrintInterpretationLineAboveCode, options);
                 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode93ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Barcode93ElementDrawer.cs
@@ -47,7 +47,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     this.DrawInterpretationLine(content, labelFont, x, y, resizedImage.Width, resizedImage.Height, barcode.FieldOrigin != null, barcode.FieldOrientation, barcode.PrintInterpretationLineAboveCode, options);
                 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeAnsiCodabarElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeAnsiCodabarElementDrawer.cs
@@ -55,7 +55,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     this.DrawInterpretationLine(interpretation, labelFont, x, y, resizedImage.Width, resizedImage.Height, barcode.FieldOrigin != null, barcode.FieldOrientation, barcode.PrintInterpretationLineAboveCode, options);
                 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeEAN13ElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeEAN13ElementDrawer.cs
@@ -71,7 +71,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     if (barcode.PrintInterpretationLineAboveCode)
                     {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeUpcAElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeUpcAElementDrawer.cs
@@ -80,7 +80,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     if (barcode.PrintInterpretationLineAboveCode)
                     {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeUpcEElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeUpcEElementDrawer.cs
@@ -118,7 +118,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     if (barcode.PrintInterpretationLineAboveCode)
                     {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeUpcExtensionElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/BarcodeUpcExtensionElementDrawer.cs
@@ -58,7 +58,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = FontScale.GetBitmappedFontSize("A", Math.Min(barcode.ModuleWidth, 10), printDensityDpmm).Value;
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     this.DrawInterpretationLine(interpretation, labelFont, x, y, resizedImage.Width, resizedImage.Height, barcode.FieldOrigin != null, barcode.FieldOrientation, barcode.PrintInterpretationLineAboveCode, options);
                 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/DrawerOptions.cs
@@ -1,4 +1,4 @@
-using SkiaSharp;
+﻿using SkiaSharp;
 
 using System;
 
@@ -7,7 +7,10 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
     public class DrawerOptions
     {
         [Obsolete("Use FontManager.FontLoader instead.")]
-        public Func<string, SKTypeface> FontLoader { get; set; }
+        public Func<string, SKTypeface> FontLoader {
+            get => FontManager.FontLoader;
+            set => FontManager.FontLoader = value;
+        }
 
         /// <summary>
         /// Gets or sets the image format used when rendering output.
@@ -51,7 +54,6 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
         public DrawerOptions(FontManager fontManager)
         {
             this.FontManager = fontManager;
-            this.FontLoader = fontManager.FontLoader;
         }
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/ElementDrawerBase.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/ElementDrawerBase.cs
@@ -7,6 +7,11 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 {
     public abstract class ElementDrawerBase : IElementDrawer
     {
+        /// <summary>
+        /// The font to use if the specified font is not found.
+        /// </summary>
+        protected const string FallbackFont = "A";
+
         internal IPrinterStorage printerStorage;
         internal SKCanvas skCanvas;
 

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/FieldBlockElementDrawer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Helpers;
 
@@ -41,16 +41,18 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
             {
                 ZplFont font = fieldBlock.Font;
 
-                (float fontSize, float scaleX) = FontScale.GetFontScaling(font.FontName, font.FontHeight, font.FontWidth, printDensityDpmm);
+                SKTypeface typeface = options.FontManager.GetFont(font.FontName, FallbackFont, out bool found);
+                string fontName = found ? font.FontName : FallbackFont;
 
-                SKTypeface typeface = options.FontManager.FontLoader(font.FontName);
+                (float fontSize, float scaleX) = FontScale.GetFontScaling(fontName, font.FontHeight, font.FontWidth, printDensityDpmm);
+
                 string text = fieldBlock.Text;
                 if (fieldBlock.HexadecimalIndicator is char hexIndicator)
                 {
                     text = text.ReplaceHexEscapes(hexIndicator, internationalFont);
                 }
 
-                if (font.FontName == "0")
+                if (fontName == "0")
                 {
                     if (options.ReplaceDashWithEnDash)
                     {

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/GraphicSymbolElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/GraphicSymbolElementDrawer.cs
@@ -34,9 +34,6 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
                (float fontSize, float scaleX) = FontScale.GetFontScaling("GS", graphicSymbol.Height, graphicSymbol.Width, printDensityDpmm);
 
-                // remove incorrect scaling
-                fontSize /= 1.1f;
-
                 SKTypeface typeface = options.FontManager.TypefaceGS;
 
                 SKFont skFont = new(typeface, fontSize * 1.25f, scaleX);

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/Interleaved2of5BarcodeDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/Interleaved2of5BarcodeDrawer.cs
@@ -1,4 +1,4 @@
-using BinaryKits.Zpl.Label;
+﻿using BinaryKits.Zpl.Label;
 using BinaryKits.Zpl.Label.Elements;
 using BinaryKits.Zpl.Viewer.Helpers;
 
@@ -53,7 +53,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                 if (barcode.PrintInterpretationLine)
                 {
                     float labelFontSize = Math.Min(barcode.ModuleWidth * 10f, 100f);
-                    SKTypeface labelTypeFace = options.FontManager.FontLoader("A");
+                    SKTypeface labelTypeFace = options.FontManager.GetFont("A");
                     SKFont labelFont = new(labelTypeFace, labelFontSize);
                     this.DrawInterpretationLine(content, labelFont, x, y, resizedImage.Width, resizedImage.Height, barcode.FieldOrigin != null, barcode.FieldOrientation, barcode.PrintInterpretationLineAboveCode, options);
                 }

--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/TextFieldElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/TextFieldElementDrawer.cs
@@ -46,9 +46,10 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
                 ZplFont font = textField.Font;
 
-                (float fontSize, float scaleX) = FontScale.GetFontScaling(font.FontName, font.FontHeight, font.FontWidth, printDensityDpmm);
+                SKTypeface typeface = options.FontManager.GetFont(font.FontName, FallbackFont, out bool found);
+                string fontName = found ? font.FontName : FallbackFont;
 
-                SKTypeface typeface = options.FontManager.FontLoader(font.FontName);
+                (float fontSize, float scaleX) = FontScale.GetFontScaling(fontName, font.FontHeight, font.FontWidth, printDensityDpmm);
 
                 SKFont skFont = new(typeface, fontSize, scaleX);
                 using SKPaint skPaint = new()
@@ -62,7 +63,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
                     displayText = displayText.ReplaceHexEscapes(hexIndicator, internationalFont);
                 }
 
-                if (font.FontName == "0")
+                if (fontName == "0")
                 {
                     if (options.ReplaceDashWithEnDash)
                     {

--- a/src/BinaryKits.Zpl.Viewer/FontManager.cs
+++ b/src/BinaryKits.Zpl.Viewer/FontManager.cs
@@ -44,12 +44,20 @@ namespace BinaryKits.Zpl.Viewer
         ];
 
         /// <summary>
-        /// Gets or sets the delegate used to load a font by name and return an SKTypeface instance.
+        /// Gets or sets the delegate used to load a font by name and return an <see cref="SKTypeface"/>.
         /// </summary>
-        /// <remarks>The delegate should accept a font name as a string and return the corresponding
-        /// SKTypeface. This property allows customization of font loading behavior, such as loading fonts from embedded
-        /// resources or external files.</remarks>
-        public Func<string, SKTypeface> FontLoader { get; set; }
+        /// <remarks>
+        /// The delegate should accept a font name as a string and return the corresponding
+        /// <see cref="SKTypeface"/>, or <see langword="null"/> if the font is not found. This property allows customization
+        /// of font loading behavior, such as loading fonts from embedded resources or external files.
+        /// </remarks>
+        public Func<string, SKTypeface> FontLoader {
+            [Obsolete("Use FontManager.GetFont instead")]
+            get => this.fontLoader; 
+            set => this.fontLoader = value ?? throw new ArgumentNullException(nameof(value)); 
+        }
+
+        private Func<string, SKTypeface> fontLoader;
 
         private static readonly SKFontStyle fontStyle0 = new(
             SKFontStyleWeight.Bold,
@@ -81,8 +89,9 @@ namespace BinaryKits.Zpl.Viewer
 
         internal SKTypeface TypefaceGS { get; } = SKTypeface.FromStream(new MemoryStream(Resources.ZplGS));
 
-        public FontManager() {
-            this.FontLoader = (fontName) => {
+        public FontManager()
+        {
+            this.fontLoader = (fontName) => {
                 if (fontName == "0")
                 {
                     return this.Typeface0;
@@ -103,7 +112,9 @@ namespace BinaryKits.Zpl.Viewer
             if (this.registeredTypefaces.TryGetValue(typeface.FamilyName, out IList<SKTypeface> typefaces))
             {
                 typefaces.Add(typeface);
-            } else {
+            }
+            else
+            {
                 this.registeredTypefaces[typeface.FamilyName] = [typeface];
             }
         }
@@ -157,5 +168,73 @@ namespace BinaryKits.Zpl.Viewer
             return null;
         }
 
+        /// <summary>
+        /// Retrieves the typeface for <paramref name="fontName"/>.
+        /// </summary>
+        /// <returns>
+        /// The requested <see cref="SKTypeface"/>.
+        /// </returns>
+        /// <exception cref="FontNotFoundException">
+        /// If <paramref name="fontName"/> is not found.
+        /// </exception>
+        /// <inheritdoc cref="GetFont(string, string, out bool)"/>
+        public SKTypeface GetFont(string fontName)
+        {
+            return this.GetFont(fontName, null, out bool _);
+        }
+
+        /// <inheritdoc cref="GetFont(string, string, out bool)"/>
+        public SKTypeface GetFont(string fontName, string fallbackFont)
+        {
+            return this.GetFont(fontName, fallbackFont, out bool _);
+        }
+
+        /// <summary>
+        /// Tries to retrieve the typeface for <paramref name="fontName"/>, falling back to <paramref name="fallbackFont"/>
+        /// if not <see langword="null"/>.
+        /// </summary>
+        /// <param name="fontName">The name of the font to find</param>
+        /// <param name="fallbackFont">The fallback font to use if <paramref name="fontName"/> is not found</param>
+        /// <param name="found">
+        /// <see langword="true"/> if <paramref name="fontName"/> is found, <see langword="false"/> otherwise.
+        /// </param>
+        /// <returns>
+        /// The requested <see cref="SKTypeface"/> or the fallback one.
+        /// </returns>
+        /// <exception cref="FontNotFoundException">
+        /// If <paramref name="fontName"/> is not found and <paramref name="fallbackFont"/> is <see langword="null"/>
+        /// or if it is not <see langword="null"/> but not found.
+        /// </exception>
+        public SKTypeface GetFont(string fontName, string fallbackFont, out bool found)
+        {
+            SKTypeface font = this.fontLoader(fontName);
+            if (font == null)
+            {
+                found = false;
+                if (fallbackFont == null)
+                {
+                    throw new FontNotFoundException(fontName);
+                }
+
+                font = this.fontLoader(fallbackFont);
+                if (font == null)
+                {
+                    throw new FontNotFoundException(fontName, fallbackFont);
+                }
+            }
+            else
+            {
+                found = true;
+            }
+
+            return font;
+        }
+    }
+
+    public class FontNotFoundException : Exception
+    {
+        internal FontNotFoundException(string fontName) : base($"Font '{fontName}' not found") { }
+
+        internal FontNotFoundException(string fontName, string fallbackFont) : base($"Font '{fontName}' and fallback font '{fallbackFont}' not found") { }
     }
 }

--- a/src/BinaryKits.Zpl.Viewer/Helpers/FontScale.cs
+++ b/src/BinaryKits.Zpl.Viewer/Helpers/FontScale.cs
@@ -131,7 +131,11 @@ namespace BinaryKits.Zpl.Viewer.Helpers
                 {
                     double heightRatio = (double)fontHeight / height;
                     int intHeightRatio = (int)Math.Max(1, Math.Round(heightRatio));
-                    float emSize = height * intHeightRatio * heightScale;
+                    float emSize = height * intHeightRatio;
+                    if (!fontName.Equals("GS"))
+                    {
+                        emSize *= heightScale;
+                    }
 
                     if (fontWidth == 0)
                     {
@@ -148,7 +152,9 @@ namespace BinaryKits.Zpl.Viewer.Helpers
                     double widthRatio = (double)fontWidth / width;
                     int intWidthRatio = (int)Math.Max(1, Math.Round(widthRatio));
 
-                    return (height * intWidthRatio * heightScale, 1.0f);
+                    return fontName.Equals("GS")
+                        ? (height * intWidthRatio, 1.0f)
+                        : (height * intWidthRatio * heightScale, 1.0f);
                 }
                 else
                 {


### PR DESCRIPTION
Right now, when a font is not found and a fallback is used, as in the default fontLoader
```cs
if (fontName == "0")
{
    return this.Typeface0;
}

return this.TypefaceA;
```
the scaling matrices are not applied, as it is just a fallback on the `SKTypeface`, not the font.

Thus we can change the logic of the fontloader (backwards compatible): if it returns `null`, the font is considered not found and a fallback can be used instead if the consumer chooses so.

An output parameter allows us to know whether we are using the fallback or not.
This way, we are truly falling back on font `A`, not just its typeface.

This changes nothing for fontLoaders that never return `null`.