### PR TITLE
Fix copy-paste-error for ellipse

### DIFF
--- a/src/BinaryKits.Zpl.Viewer/ElementDrawers/GraphicEllipseElementDrawer.cs
+++ b/src/BinaryKits.Zpl.Viewer/ElementDrawers/GraphicEllipseElementDrawer.cs
@@ -15,7 +15,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
         public override bool IsReverseDraw(ZplElementBase element)
         {
-            if (element is ZplGraphicCircle graphicEllipse)
+            if (element is ZplGraphicEllipse graphicEllipse)
             {
                 return graphicEllipse.ReversePrint;
             }
@@ -25,7 +25,7 @@ namespace BinaryKits.Zpl.Viewer.ElementDrawers
 
         public override bool IsWhiteDraw(ZplElementBase element)
         {
-            if (element is ZplGraphicCircle graphicEllipse)
+            if (element is ZplGraphicEllipse graphicEllipse)
             {
                 return graphicEllipse.LineColor == LineColor.White;
             }


### PR DESCRIPTION
Fixes a copy-paste error for ellipse (referenced a circle in the ellipse code)